### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/plugins/hangouts/src/Hangouts.php
+++ b/plugins/hangouts/src/Hangouts.php
@@ -38,7 +38,7 @@ class Hangouts extends Plugin
         Craft::$app->view->hook('hangouts', '\\selvinortiz\\hangouts\\twig\\HangoutsTemplateHooks::hangouts');
         Craft::$app->view->hook('hangout', '\\selvinortiz\\hangouts\\twig\\HangoutsTemplateHooks::hangout');
         Craft::$app->view->hook('profile', '\\selvinortiz\\hangouts\\twig\\HangoutsTemplateHooks::profile');
-        Craft::$app->view->twig->addExtension(new HangoutsTemplateExtension());
+        Craft::$app->view->registerTwigExtension(new HangoutsTemplateExtension());
 
         Event::on(
             UrlManager::class,


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.