### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/plugins/swipe/src/Swipe.php
+++ b/plugins/swipe/src/Swipe.php
@@ -46,7 +46,7 @@ class Swipe extends Plugin
     {
         parent::init();
 
-        Craft::$app->view->twig->addExtension(new SwipeExtension());
+        Craft::$app->view->registerTwigExtension(new SwipeExtension());
 
         Event::on(
             UrlManager::class,


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.